### PR TITLE
check if the Action is an Action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-slider",
   "description": "Swipeable image slider",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "index.js",
   "license": "ISC",
   "author": "Adalo",

--- a/src/components/ImageSlider/ImageList.js
+++ b/src/components/ImageSlider/ImageList.js
@@ -101,7 +101,7 @@ class ImageList extends Component {
       autoplay: { enabled: enableAutoplay },
     } = this.props
     const { scrollAction } = images[index]
-    if (scrollAction === "function") scrollAction(index)
+    if (typeof scrollAction === "function") scrollAction(index)
 
     this.setState({ activeIndex: index })
 

--- a/src/components/ImageSlider/ImageList.js
+++ b/src/components/ImageSlider/ImageList.js
@@ -101,7 +101,7 @@ class ImageList extends Component {
       autoplay: { enabled: enableAutoplay },
     } = this.props
     const { scrollAction } = images[index]
-    if (scrollAction) scrollAction(index)
+    if (scrollAction === "function") scrollAction(index)
 
     this.setState({ activeIndex: index })
 


### PR DESCRIPTION
[Ticket](https://trello.com/c/A3907539/2556-app-crashes-in-testflight)
----

When turning on autoplay together with a placeholder image, the image-slider will crash. Besides `scrollAction` is defined as an action on `manifest.json`, it is sendintg the placeholder image url instead and `function`. I've changed the validation to execute the action only it's a `function` rather than execute it if it exists.