### PR TITLE
🐞  Click Actions on Image Slider with One Image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-slider",
   "description": "Swipeable image slider",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "index.js",
   "license": "ISC",
   "author": "Adalo",

--- a/src/components/ImageSlider/ImageScrollView.web.js
+++ b/src/components/ImageSlider/ImageScrollView.web.js
@@ -16,6 +16,20 @@ const ImageScrollView = React.forwardRef((props, ref) => {
     onClickWeb,
   } = props
 
+  if (images.length === 1) {
+    return (
+      <TouchableWithoutFeedback
+        onPress={() => {
+          images[0].action && images[0].action()
+        }}
+      >
+        <View style={[styles.imageWrapper, innerWrapper]}>
+          <ImageItem image={images[0].image} />
+        </View>
+      </TouchableWithoutFeedback>
+    )
+  }
+
   return (
     <ScrollContainer
       horizontal={true}


### PR DESCRIPTION
## Problem
There was an issue where click actions on image sliders with one image weren't working on web.

There is an issue having to do with the `react-indiana-drag-scroll` library.

## Solution
Just render a static `ImageItem` if there's only one image.