### PR TITLE
Adding check for web browser for PWA apps.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Problem
+*Describe the specific bug or product issue that's being fixed.*
+
+## Solution
+*What did you do to fix it? Remember gif's or video of frontend fixes.*
+
+
+## Tests
+- [ ] Added tests to cover the bug or new functionalities being added
+
+## New Indexes
+
+- [ ] Added indexes for any new SQL queries.
+
+## Additional Notes (optional)
+
+- Link to Tech Spec in Notion
+
+
+## Related PRs (optional)
+
+## New Packages, Environment Variables (optional)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-slider",
   "description": "Swipeable image slider",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "index.js",
   "license": "ISC",
   "author": "Adalo",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-slider",
   "description": "Swipeable image slider",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "index.js",
   "license": "ISC",
   "author": "Adalo",

--- a/src/components/ImageSlider/ImageList.js
+++ b/src/components/ImageSlider/ImageList.js
@@ -61,6 +61,17 @@ class ImageList extends Component {
     }
   }
 
+  isWebBrowser = () => {
+    if (
+      Platform.OS === 'web' ||
+      (Platform.OS !== 'ios' && Platform.OS !== 'android' && Platform.OS !== 'native')
+    ) {
+      return true
+    } else {
+      return false
+    }
+  }
+
   calculateIndex = offsetX => {
     let { containerWidth } = this.props
     let index = Math.round(offsetX / containerWidth)
@@ -224,7 +235,7 @@ class ImageList extends Component {
       />
     )
 
-    const imageScrollView = this.isMobileDevice() ? (
+    const imageScrollView = this.isMobileDevice() && !this.isWebBrowser() ? (
       <ImageScrollViewMobile
         handleScroll={this.handleScroll}
         handlePress={this.handlePress}


### PR DESCRIPTION
## Problem
Images do not change when on PWA on device through share or preview but do change in editor preview.

## Solution
The PWA was being treated like a native app, and using the wrong React Native View.  Added web browser check to differentiate PWAs from native apps.

https://trello.com/c/dzLHZ4tv/720-image-slider-images-do-not-change-on-pwa-08-02-2022

